### PR TITLE
Shorten overlong method name

### DIFF
--- a/storm-boot-framework/src/main/java/cn/miniants/framework/advice/MiniControllerResultAdvice.java
+++ b/storm-boot-framework/src/main/java/cn/miniants/framework/advice/MiniControllerResultAdvice.java
@@ -121,7 +121,7 @@ public class MiniControllerResultAdvice implements ResponseBodyAdvice<Object> {
      * @param constraintViolationException
      * @return
      */
-    private String convertConstraintViolationsToMessage(ConstraintViolationException constraintViolationException) {
+    private String convertConstraintViolationsToMsg(ConstraintViolationException constraintViolationException) {
         return Optional.ofNullable(constraintViolationException.getConstraintViolations())
                 .filter(constraintViolations -> this.enableValidationMessage)
                 .map(constraintViolations -> constraintViolations.stream().flatMap(constraintViolation -> {
@@ -224,7 +224,7 @@ public class MiniControllerResultAdvice implements ResponseBodyAdvice<Object> {
                 res = ApiResult.failed(e.getMessage());
             }
         } else if (e instanceof ConstraintViolationException) {
-            res = ApiResult.failed(this.convertConstraintViolationsToMessage((ConstraintViolationException) e));
+            res = ApiResult.failed(this.convertConstraintViolationsToMsg((ConstraintViolationException) e));
         }else if (e instanceof MethodArgumentTypeMismatchException) {
             resp.setStatus(301);
             return ApiResult.failed("请求参数错误");


### PR DESCRIPTION
Short method name still follows a standard naming convention and accurately describes the purpose of the method in a more concise way. The short name is easier to read and type.